### PR TITLE
reduce xml uploader concurrency to 20

### DIFF
--- a/src/uploaders/serverless.yml
+++ b/src/uploaders/serverless.yml
@@ -112,7 +112,7 @@ functions:
     events:
       - s3: xmlRefData
         event: s3:ObjectCreated:*
-    reservedConcurrency: 40
+    reservedConcurrency: 20
     alarms:
       - name: functionDuration
         threshold: 50000


### PR DESCRIPTION
# Description

-   reduce xml uploader concurrency to 20 from 40

# Testing instructions

-   No local testing required, currently 20 on pre-prod and is working without issue

# Type of change

-   [ ] feat - A new feature
-   [x] fix - A bug fix
-   [ ] docs - Documentation only changes
-   [ ] codestyle - Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-   [ ] refactor - A code change that neither fixes a bug nor adds a feature
-   [ ] perf - A code change that improves performance
-   [ ] test - Adding missing tests or correcting existing tests
-   [ ] build - Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
-   [ ] ci - Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
-   [ ] chore - Other changes that don't modify src or test files
-   [ ] revert - Reverts a previous commit
-   [ ] content - Changes to content or copy

# Checklist:

-   [ ] Able to run pr locally
-   [ ] Lighthouse performed
-   [ ] Followed acceptance criteria
-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation if applicable
-   [ ] I have added tests that prove my fix is effective or that my feature works
